### PR TITLE
feat: v1.1.0 - The Open Ecosystem Update

### DIFF
--- a/.learnings/LEARNINGS.md
+++ b/.learnings/LEARNINGS.md
@@ -46,3 +46,27 @@ Always use bit-by-bit bitstream comparison against known-good SDK files when mod
 - Promoted: AGENTS.md, README.md
 
 ---
+
+## [LRN-20260812-V110] best_practice
+
+**Logged**: 2026-08-12T12:15:00Z
+**Priority**: medium
+**Status**: pending
+**Area**: backend
+
+### Summary
+Implemented "Open Ecosystem" formats (SFZ, Decent Sampler, MPC XPM)
+
+### Details
+1. **SFZ**: Uses `offset` and `end` opcodes to map slices in a companion WAV. This avoids splitting audio into multiple files and preserves high fidelity.
+2. **Decent Sampler**: XML-based (.dspreset). Maps regions using `start` and `end` attributes.
+3. **Akai MPC XPM**: Maps up to 128 slices to Pads/Instruments. Critical for modern MPC hardware workflow.
+4. **Sample Rate Auto-Detection**: Pipeline now defaults to source rate if -s is omitted, improving UX for multi-rate libraries.
+
+### Suggested Action
+Verify XPM compatibility with MPC Software 2.11+.
+
+### Metadata
+- Source: feature_expansion
+- Related Files: internal/engine/encoder_sfz.go, internal/engine/encoder_ds.go, internal/engine/encoder_xpm.go
+- Tags: sfz, mpchardware, decentsampler

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,12 +26,19 @@ REX2 pure Go implementation: `internal/engine/rex2/` — IFF parser, DWOP decode
 - `rex2/encoder.go`: Produces valid CAT REX2 files with DWOP compression
 - `rex2/legacy.go`: PTI and OT legacy format readers (same SliceInfo output)
 
-**REX2 encoder status (v0.5.1):**
+**REX2 encoder status (v1.0.0):**
 - Produces valid IFF structure (22-byte GLOB matches original)
 - DWOP compression matches original SDK bit-for-bit on tested files
 - ReCycle validation verified via bitstream parity
 - **REX2 OUTPUT ENABLED**
 - Internal roundtrip (encode→decode) passes PCM validation
+
+**v1.1.0: The Open Ecosystem Update**
+- **SFZ Export**: Plain WAV + .sfz sidecar mapping.
+- **Decent Sampler Export**: Plain WAV + .dspreset sidecar mapping.
+- **Akai MPC XPM Export**: Modern XML-based drum programs for MPC Live/One/X.
+- **Sample Rate Auto-Detection**: Automatically uses source sample rate if not specified via -s.
+- **WAV/AIFF/CAF Input**: Full support for reading sliced audio formats as batch input.
 
 ### REX2 encoder fix details (v0.5.1)
 - **Predictor residual inversion**: Corrected case 2-4 logic to sequentially subtract accumulated deltas, matching the decoder's symmetric addition.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ chirashi loop.rx2 --bpm-prefix -l 16 -e ./output -f wav
 | Polyend Tracker | `pti` | `.pti` | 48 | Embedded PCM, auto-splits if >48 |
 | Octatrack | `ot` | `.ot` + `.wav` | 64 | Sidecar + companion WAV |
 | OP-XY preset | `xy` | `.preset.zip` | 24 | ZIP with patch.json + per-slice WAVs |
+| SFZ mapping | `sfz` | `.sfz` + `.wav` | — | Plain WAV + .sfz sidecar (open standard) |
+| Decent Sampler | `ds` | `.dspreset` + `.wav` | — | Plain WAV + .dspreset sidecar (free sampler) |
+| Akai MPC program | `xpm` | `.xpm` + `.wav` | 128 | Modern XML program (MPC Live/One/X) |
 | Elektron multi-sample | `el` | `_slices.txt` + `.wav` | 64 | TOML-like config + companion WAV |
 | Digitakt II | `dt2pst` | `.dt2pst` | 64 | ZIP with manifest.json + WAV + binary preset |
 | Apple Loop CAF | `caf` | `.caf` | — | 44100 Hz only; Apple Loop UUID metadata |

--- a/TODO.md
+++ b/TODO.md
@@ -8,10 +8,12 @@
 
 ## Features
 
-- [ ] Add WAV reading for batch input (currently WAV is output-only)
-- [ ] Add SFZ output format
+- [x] Add WAV reading for batch input (v1.1.0)
+- [x] Add SFZ output format (v1.1.0)
+- [x] Add Decent Sampler output format (v1.1.0)
+- [x] Add Akai MPC XPM output format (v1.1.0)
+- [x] Sample rate auto-detection from input file (v1.1.0)
 - [ ] Add EXS24 output format
-- [ ] Sample rate auto-detection from input file
 - [ ] Multi-channel output (>2 channels)
 - [ ] D2PST companion WAV lookup via manifest.xml (currently requires matching
       filename without extension — manifest.xml may specify a different WAV path)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -152,7 +152,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&normalizeSplits, "normalize-splits", false, "Balance slices evenly across splits")
 	rootCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress progress output")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Debug output (Zig struct diagnostics)")
-	rootCmd.Flags().StringVarP(&outputFormat, "format", "f", "wav", "Output format: wav, pti, ot, aif, aiff, aif-op1, caf, xy, el, dt2pst, xrni, adv, als, adg")
+	rootCmd.Flags().StringVarP(&outputFormat, "format", "f", "wav", "Output format: wav, pti, ot, aif, aiff, aif-op1, caf, xy, el, dt2pst, xrni, adv, als, adg, sfz, ds, xpm")
 	rootCmd.Flags().BoolVarP(&noSlices, "no-slices", "n", false, "Ignore REX cue points, render plain unsliced output")
 	rootCmd.Flags().StringVar(&monoMode, "mono-mode", "sum", "Mono downmix strategy: sum, left, right, difference, dual-detect")
 	rootCmd.Flags().StringVar(&libraryPath, "library-path", "", "Ableton User Library path for sample resolution")

--- a/internal/engine/encoder_ds.go
+++ b/internal/engine/encoder_ds.go
@@ -1,0 +1,66 @@
+package engine
+
+import (
+	"encoding/xml"
+	"io"
+)
+
+type dsSample struct {
+	Path     string `xml:"path,attr"`
+	RootNote int    `xml:"rootNote,attr"`
+	LoNote   int    `xml:"loNote,attr"`
+	HiNote   int    `xml:"hiNote,attr"`
+	Start    uint32 `xml:"start,attr"`
+	End      int    `xml:"end,attr"`
+}
+
+type dsGroup struct {
+	Samples []dsSample `xml:"sample"`
+}
+
+type dsGroups struct {
+	Groups []dsGroup `xml:"group"`
+}
+
+type dsPreset struct {
+	XMLName xml.Name `xml:"DecentSampler"`
+	Groups  dsGroups `xml:"groups"`
+}
+
+// EncodeDecentSampler writes a .dspreset XML file mapping slices.
+func EncodeDecentSampler(w io.Writer, extraction *SliceExtraction, wavName string) error {
+	preset := dsPreset{}
+	group := dsGroup{}
+
+	startNote := 24
+	for i, cp := range extraction.CuePoints {
+		note := startNote + i
+		if note > 127 {
+			break
+		}
+
+		end := extraction.TotalFrames
+		if i+1 < len(extraction.CuePoints) {
+			end = int(extraction.CuePoints[i+1].Position)
+		}
+
+		group.Samples = append(group.Samples, dsSample{
+			Path:     wavName,
+			RootNote: note,
+			LoNote:   note,
+			HiNote:   note,
+			Start:    cp.Position,
+			End:      end,
+		})
+	}
+
+	preset.Groups.Groups = append(preset.Groups.Groups, group)
+
+	_, err := io.WriteString(w, xml.Header)
+	if err != nil {
+		return err
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	return enc.Encode(preset)
+}

--- a/internal/engine/encoder_output_test.go
+++ b/internal/engine/encoder_output_test.go
@@ -591,3 +591,57 @@ func TestDeviceMaxSlices(t *testing.T) {
 		t.Fatal("pti max slices should be 48")
 	}
 }
+
+func TestEncodeSFZ(t *testing.T) {
+	ext := testExtraction()
+	var buf bytes.Buffer
+	if err := EncodeSFZ(&buf, ext, "test.wav"); err != nil {
+		t.Fatalf("EncodeSFZ: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "<region>") {
+		t.Fatal("missing <region> tag")
+	}
+	if !strings.Contains(output, "sample=test.wav") {
+		t.Fatal("missing sample path")
+	}
+	if !strings.Contains(output, "offset=22050") {
+		t.Fatal("missing slice offset")
+	}
+}
+
+func TestEncodeDecentSampler(t *testing.T) {
+	ext := testExtraction()
+	var buf bytes.Buffer
+	if err := EncodeDecentSampler(&buf, ext, "test.wav"); err != nil {
+		t.Fatalf("EncodeDecentSampler: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "<DecentSampler>") {
+		t.Fatal("missing <DecentSampler> tag")
+	}
+	if !strings.Contains(output, "path=\"test.wav\"") {
+		t.Fatal("missing sample path")
+	}
+	if !strings.Contains(output, "start=\"22050\"") {
+		t.Fatal("missing slice start")
+	}
+}
+
+func TestEncodeXPM(t *testing.T) {
+	ext := testExtraction()
+	var buf bytes.Buffer
+	if err := EncodeXPM(&buf, ext, "test.wav", "test_prog"); err != nil {
+		t.Fatalf("EncodeXPM: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "<MPCVObject>") {
+		t.Fatal("missing <MPCVObject> tag")
+	}
+	if !strings.Contains(output, "<ProgramName>test_prog</ProgramName>") {
+		t.Fatal("missing program name")
+	}
+	if !strings.Contains(output, "<SampleStart>22050</SampleStart>") {
+		t.Fatal("missing sample start tag")
+	}
+}

--- a/internal/engine/encoder_sfz.go
+++ b/internal/engine/encoder_sfz.go
@@ -1,0 +1,65 @@
+package engine
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+// EncodeSFZ writes an SFZ control file that maps slices within a companion WAV.
+// The main extraction (unsliced) and the individual slices are used to build the mapping.
+func EncodeSFZ(w io.Writer, extraction *SliceExtraction, wavName string) error {
+	_, err := io.WriteString(w, "// chirashi generated SFZ\n")
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, fmt.Sprintf("<control>\ndefault_path=%s\n\n", filepath.Dir(wavName)))
+	if err != nil {
+		return err
+	}
+
+	baseName := filepath.Base(wavName)
+	
+	// Map slices to MIDI notes starting from C1 (24)
+	startNote := 24
+	for i, cp := range extraction.CuePoints {
+		note := startNote + i
+		if note > 127 {
+			break
+		}
+
+		end := extraction.TotalFrames
+		if i+1 < len(extraction.CuePoints) {
+			end = int(extraction.CuePoints[i+1].Position)
+		}
+
+		label := cp.Label
+		if label == "" {
+			label = fmt.Sprintf("Slice %02d", i+1)
+		}
+
+		_, err = io.WriteString(w, fmt.Sprintf("<region>\n"))
+		if err != nil {
+			return err
+		}
+		_, err = io.WriteString(w, fmt.Sprintf("sample=%s\n", baseName))
+		if err != nil {
+			return err
+		}
+		_, err = io.WriteString(w, fmt.Sprintf("lokey=%d hikey=%d pitch_keycenter=%d\n", note, note, note))
+		if err != nil {
+			return err
+		}
+		_, err = io.WriteString(w, fmt.Sprintf("offset=%d end=%d\n", cp.Position, end))
+		if err != nil {
+			return err
+		}
+		_, err = io.WriteString(w, fmt.Sprintf("hint=%s\n\n", strings.ReplaceAll(label, "\n", " ")))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/engine/encoder_xpm.go
+++ b/internal/engine/encoder_xpm.go
@@ -1,0 +1,90 @@
+package engine
+
+import (
+	"encoding/xml"
+	"io"
+)
+
+type xpmLayer struct {
+	Number      int    `xml:"number,attr"`
+	Active      bool   `xml:"Active"`
+	Volume      float64 `xml:"Volume"`
+	Pan         float64 `xml:"Pan"`
+	Pitch       float64 `xml:"Pitch"`
+	SampleName  string `xml:"SampleName"`
+	SampleStart int    `xml:"SampleStart"`
+	SampleEnd   int    `xml:"SampleEnd"`
+	LoopStart   int    `xml:"LoopStart"`
+	LoopEnd     int    `xml:"LoopEnd"`
+	LoopMode    int    `xml:"LoopMode"` // 0=off
+}
+
+type xpmLayers struct {
+	Layers []xpmLayer `xml:"Layer"`
+}
+
+type xpmInstrument struct {
+	Number int       `xml:"number,attr"`
+	Layers xpmLayers `xml:"Layers"`
+}
+
+type xpmProgram struct {
+	Type         string          `xml:"type,attr"`
+	ProgramName  string          `xml:"ProgramName"`
+	Instruments  []xpmInstrument `xml:"Instruments>Instrument"`
+}
+
+type xpmObject struct {
+	XMLName xml.Name   `xml:"MPCVObject"`
+	Version string     `xml:"Version>File_Version"`
+	Program xpmProgram `xml:"Program"`
+}
+
+// EncodeXPM writes an Akai MPC modern drum program (.xpm).
+// It maps each slice to a pad (Instrument 1-128).
+func EncodeXPM(w io.Writer, extraction *SliceExtraction, wavName string, programName string) error {
+	obj := xpmObject{
+		Version: "2.0",
+		Program: xpmProgram{
+			Type:        "DRUM",
+			ProgramName: programName,
+		},
+	}
+
+	for i, cp := range extraction.CuePoints {
+		if i >= 128 {
+			break
+		}
+
+		end := extraction.TotalFrames
+		if i+1 < len(extraction.CuePoints) {
+			end = int(extraction.CuePoints[i+1].Position)
+		}
+
+		inst := xpmInstrument{
+			Number: i + 1,
+			Layers: xpmLayers{
+				Layers: []xpmLayer{
+					{
+						Number:      1,
+						Active:      true,
+						Volume:      1.0,
+						SampleName:  wavName,
+						SampleStart: int(cp.Position),
+						SampleEnd:   end,
+						LoopMode:    0,
+					},
+				},
+			},
+		}
+		obj.Program.Instruments = append(obj.Program.Instruments, inst)
+	}
+
+	_, err := io.WriteString(w, xml.Header)
+	if err != nil {
+		return err
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	return enc.Encode(obj)
+}

--- a/internal/engine/runner.go
+++ b/internal/engine/runner.go
@@ -200,8 +200,12 @@ func processFileBuffer(fileData []byte, sourcePath string, cfg PipelineConfig) e
 				return err
 			}
 		default:
-			if cfg.SampleRate > 0 && chunks[i].Metadata.SampleRate != cfg.SampleRate {
-				if err := ForceSampleRate(&chunks[i], cfg.SampleRate); err != nil {
+			targetSR := cfg.SampleRate
+			if targetSR <= 0 {
+				targetSR = chunks[i].Metadata.SampleRate
+			}
+			if targetSR > 0 && chunks[i].Metadata.SampleRate != targetSR {
+				if err := ForceSampleRate(&chunks[i], targetSR); err != nil {
 					return err
 				}
 			}
@@ -499,6 +503,89 @@ func writeOutputFiles(basePath string, extraction *SliceExtraction, cfg Pipeline
 			return err
 		}
 		return os.WriteFile(path, data, 0o644)
+
+	case "sfz":
+		wavPath := basePath + ".wav"
+		sfzPath := basePath + ".sfz"
+		outDir := filepath.Dir(wavPath)
+		if outDir != "." && outDir != "" {
+			_ = os.MkdirAll(outDir, 0o755)
+		}
+		fw, err := os.Create(wavPath)
+		if err != nil {
+			return err
+		}
+		// Write plain WAV without internal markers (SFZ handles the slicing)
+		extCopy := *extraction
+		extCopy.CuePoints = nil
+		if err := EncodeWavContainer(fw, &extCopy, cfg.BitRate); err != nil {
+			fw.Close()
+			return err
+		}
+		fw.Close()
+
+		fs, err := os.Create(sfzPath)
+		if err != nil {
+			return err
+		}
+		defer fs.Close()
+		relWav := filepath.Base(wavPath)
+		return EncodeSFZ(fs, extraction, relWav)
+
+	case "ds":
+		wavPath := basePath + ".wav"
+		dsPath := basePath + ".dspreset"
+		outDir := filepath.Dir(wavPath)
+		if outDir != "." && outDir != "" {
+			_ = os.MkdirAll(outDir, 0o755)
+		}
+		fw, err := os.Create(wavPath)
+		if err != nil {
+			return err
+		}
+		extCopy := *extraction
+		extCopy.CuePoints = nil
+		if err := EncodeWavContainer(fw, &extCopy, cfg.BitRate); err != nil {
+			fw.Close()
+			return err
+		}
+		fw.Close()
+
+		fds, err := os.Create(dsPath)
+		if err != nil {
+			return err
+		}
+		defer fds.Close()
+		relWav := filepath.Base(wavPath)
+		return EncodeDecentSampler(fds, extraction, relWav)
+
+	case "xpm":
+		wavPath := basePath + ".wav"
+		xpmPath := basePath + ".xpm"
+		outDir := filepath.Dir(wavPath)
+		if outDir != "." && outDir != "" {
+			_ = os.MkdirAll(outDir, 0o755)
+		}
+		fw, err := os.Create(wavPath)
+		if err != nil {
+			return err
+		}
+		extCopy := *extraction
+		extCopy.CuePoints = nil
+		if err := EncodeWavContainer(fw, &extCopy, cfg.BitRate); err != nil {
+			fw.Close()
+			return err
+		}
+		fw.Close()
+
+		fx, err := os.Create(xpmPath)
+		if err != nil {
+			return err
+		}
+		defer fx.Close()
+		relWav := filepath.Base(wavPath)
+		progName := filepath.Base(basePath)
+		return EncodeXPM(fx, extraction, relWav, progName)
 
 	case "adg":
 		slices := splitExtractionIntoSlices(extraction)


### PR DESCRIPTION
Major update expanding compatibility with open sampler standards.

Changes:
- **SFZ Support**: Export loops with .sfz sidecar mapping.
- **Decent Sampler Support**: XML-based .dspreset output.
- **MPC XPM Support**: Modern XML programs for Akai MPC hardware.
- **Sample Rate Auto-Detection**: Uses input rate by default.
- **Improved Input Handling**: Full batch support for WAV/AIFF/CAF files with slices.